### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,24 @@
 version: 2
 
 updates:
-  - package-ecosystem: pip
-    directory: /
+  - package-ecosystem: uv
+    directory: /convert-attestations
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      python:
+      uv-dependencies:
         patterns:
           - "*"
-    schedule:
-      interval: daily
 
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      actions:
+      actions-dependencies:
         patterns:
           - "*"
-    schedule:
-      interval: daily


### PR DESCRIPTION
## Summary
- Switch `pip` ecosystem to `uv` (repo uses `uv.lock`, not pip)
- Fix directory from `/` to `/convert-attestations` where `pyproject.toml` lives
- Change schedule from `daily` to `weekly`
- Add 7-day cooldown to prevent PR flooding after close/merge
- Maintain grouped update patterns for both ecosystems

🤖 Generated with [Claude Code](https://claude.com/claude-code)